### PR TITLE
Add initial sources upload vertical slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,14 @@ __marimo__/
 docker-compose.override.yml
 .docker/
 
+# Node / Next.js
+node_modules/
+.next/
+web/.next/
+web/node_modules/
+web/.turbo/
+web/.eslintcache
+
 # Application logs
 logs/
 *.log

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,6 +11,7 @@ from alembic import context
 # Import your app's config and models
 from app.config import settings
 from app.database import Base
+from app.ingestion import models as ingestion_models  # noqa: F401
 
 # This is the Alembic Config object
 config = context.config

--- a/alembic/versions/202502110000_create_sources_table.py
+++ b/alembic/versions/202502110000_create_sources_table.py
@@ -1,0 +1,36 @@
+"""create sources table"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "202502110000"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sources",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("owner_user_id", sa.String(length=255), nullable=True),
+        sa.Column("original_file_name", sa.String(length=255), nullable=False),
+        sa.Column("content_type", sa.String(length=128), nullable=False),
+        sa.Column("file_path", sa.String(length=1024), nullable=False),
+        sa.Column("file_size", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_sources_owner_user_id"), "sources", ["owner_user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_sources_owner_user_id"), table_name="sources")
+    op.drop_table("sources")

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,11 @@
+"""Authentication placeholders and helpers."""
+
+
+def get_current_user_id() -> str:
+    """Placeholder for future OIDC integration.
+
+    Returns a fixed user ID for local development to simplify wiring in future
+    authentication without changing the data model.
+    """
+
+    return "local-dev"

--- a/app/ingestion/__init__.py
+++ b/app/ingestion/__init__.py
@@ -1,3 +1,5 @@
-"""
-Ingestion module: Parse, chunk, embed, and index sources.
-"""
+"""Ingestion package."""
+
+from app.ingestion.models import Source
+
+__all__ = ["Source"]

--- a/app/ingestion/models.py
+++ b/app/ingestion/models.py
@@ -1,0 +1,27 @@
+"""Database models for ingestion domain."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.database import Base
+
+
+class Source(Base):
+    """A user-provided source stored in the system."""
+
+    __tablename__ = "sources"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    title = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    owner_user_id = Column(String(255), nullable=True, index=True)
+    original_file_name = Column(String(255), nullable=False)
+    content_type = Column(String(128), nullable=False)
+    file_path = Column(String(1024), nullable=False)
+    file_size = Column(Integer, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/app/ingestion/routes.py
+++ b/app/ingestion/routes.py
@@ -1,0 +1,92 @@
+"""Routes for managing user sources."""
+
+import os
+import uuid
+from pathlib import Path
+from typing import List
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user_id
+from app.config import settings
+from app.database import get_db
+from app.ingestion.models import Source
+from app.ingestion.schemas import SourceResponse
+
+router = APIRouter(prefix="/v1/sources", tags=["sources"])
+
+
+async def _persist_upload_file(upload: UploadFile, destination_dir: str) -> tuple[str, int]:
+    """Save the uploaded file to disk and return its path and size."""
+
+    os.makedirs(destination_dir, exist_ok=True)
+    file_extension = Path(upload.filename or "").suffix
+    unique_name = f"{uuid.uuid4()}{file_extension}"
+    target_path = Path(destination_dir) / unique_name
+
+    file_bytes = await upload.read()
+    target_path.write_bytes(file_bytes)
+
+    return str(target_path), len(file_bytes)
+
+
+@router.get("", response_model=List[SourceResponse])
+async def list_sources(db: AsyncSession = Depends(get_db)) -> List[SourceResponse]:
+    """List all sources for the current user."""
+
+    current_user_id = get_current_user_id()
+    result = await db.execute(
+        select(Source)
+        .where(Source.owner_user_id == current_user_id)
+        .order_by(Source.created_at.desc())
+    )
+    sources = result.scalars().all()
+    return [SourceResponse.model_validate(source) for source in sources]
+
+
+@router.get("/{source_id}", response_model=SourceResponse)
+async def get_source_detail(
+    source_id: uuid.UUID, db: AsyncSession = Depends(get_db)
+) -> SourceResponse:
+    """Fetch a single source by ID."""
+
+    source = await db.get(Source, source_id)
+    if source is None or source.owner_user_id != get_current_user_id():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Source not found")
+
+    return SourceResponse.model_validate(source)
+
+
+@router.post("", response_model=SourceResponse, status_code=status.HTTP_201_CREATED)
+async def create_source(
+    title: str = Form(...),
+    description: str | None = Form(None),
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+) -> SourceResponse:
+    """Upload a PDF and create a source record."""
+
+    if file.content_type not in {"application/pdf", "application/x-pdf"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only PDF uploads are supported at this time.",
+        )
+
+    file_path, file_size = await _persist_upload_file(file, settings.UPLOAD_DIR)
+
+    source = Source(
+        title=title,
+        description=description,
+        original_file_name=file.filename or "uploaded.pdf",
+        content_type=file.content_type or "application/pdf",
+        file_path=file_path,
+        file_size=file_size,
+        owner_user_id=get_current_user_id(),
+    )
+
+    db.add(source)
+    await db.flush()
+
+    return SourceResponse.model_validate(source)

--- a/app/ingestion/schemas.py
+++ b/app/ingestion/schemas.py
@@ -1,0 +1,31 @@
+"""Pydantic schemas for source ingestion."""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class SourceBase(BaseModel):
+    title: str
+    description: Optional[str] = None
+
+
+class SourceCreate(SourceBase):
+    pass
+
+
+class SourceResponse(SourceBase):
+    id: UUID
+    owner_user_id: Optional[str] = Field(default=None)
+    original_file_name: str
+    content_type: str
+    file_size: int
+    file_path: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.ingestion.routes import router as sources_router
 
 app = FastAPI(
     title="Studium API",
@@ -23,6 +24,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(sources_router)
 
 
 @app.get("/")

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,0 +1,101 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #f7f7f8;
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid #e5e7eb;
+  background: white;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 18px;
+}
+
+nav a {
+  margin-left: 16px;
+  color: #0f172a;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+.container {
+  max-width: 960px;
+  margin: 24px auto;
+  padding: 0 16px;
+}
+
+.card {
+  background: white;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  margin-bottom: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 12px;
+}
+
+.form-group label {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.form-group input,
+.form-group textarea {
+  padding: 10px;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  font-size: 14px;
+}
+
+.button {
+  display: inline-block;
+  padding: 10px 16px;
+  background: #0ea5e9;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+}
+
+.meta {
+  color: #475569;
+  font-size: 14px;
+}
+
+.empty-state {
+  text-align: center;
+  color: #475569;
+  padding: 32px;
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Studium',
+  description: 'Strict-evidence study companion',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="app-header">
+          <div className="brand">Studium</div>
+          <nav>
+            <Link href="/sources">Sources</Link>
+            <Link href="/sources/new">Add Source</Link>
+          </nav>
+        </header>
+        <main className="container">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function HomePage() {
+  redirect('/sources');
+}

--- a/web/app/sources/[id]/page.tsx
+++ b/web/app/sources/[id]/page.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import { apiFetch } from '../../../lib/api';
+import type { Source } from '../../../types/sources';
+
+type SourcePageProps = {
+  params: { id: string };
+};
+
+async function loadSource(id: string): Promise<Source> {
+  return apiFetch<Source>(`/v1/sources/${id}`);
+}
+
+export default async function SourceDetailPage({ params }: SourcePageProps) {
+  const { id } = params;
+  const source = await loadSource(id);
+
+  return (
+    <div className="card">
+      <div className="meta">
+        <Link href="/sources">← Back to sources</Link>
+      </div>
+      <h1>{source.title}</h1>
+      {source.description ? <p>{source.description}</p> : null}
+
+      <div className="meta">
+        <div>Original file: {source.original_file_name}</div>
+        <div>MIME type: {source.content_type}</div>
+        <div>Stored at: {source.file_path}</div>
+        <div>Uploaded: {new Date(source.created_at).toLocaleString()}</div>
+        <div>Owner: {source.owner_user_id ?? 'Unassigned'}</div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/sources/new/page.tsx
+++ b/web/app/sources/new/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FormEvent, useState } from 'react';
+import { apiBaseUrl } from '../../../lib/api';
+
+export default function NewSourcePage() {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const formData = new FormData(event.currentTarget);
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/sources`, {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Failed to upload source');
+      }
+
+      router.push('/sources');
+      router.refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Upload failed';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <h1>Add a Source</h1>
+      <form onSubmit={handleSubmit}>
+        <div className="form-group">
+          <label htmlFor="title">Title</label>
+          <input id="title" name="title" type="text" required placeholder="My PDF" />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="description">Description</label>
+          <textarea id="description" name="description" rows={4} placeholder="Optional context" />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="file">PDF file</label>
+          <input id="file" name="file" type="file" accept="application/pdf" required />
+        </div>
+
+        {error ? <div className="meta" style={{ color: 'crimson' }}>{error}</div> : null}
+
+        <button className="button" type="submit" disabled={submitting}>
+          {submitting ? 'Uploading…' : 'Upload PDF'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/app/sources/page.tsx
+++ b/web/app/sources/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import { apiFetch } from '../../lib/api';
+import type { Source } from '../../types/sources';
+
+async function loadSources(): Promise<Source[]> {
+  return apiFetch<Source[]>('/v1/sources');
+}
+
+function formatSize(bytes: number) {
+  const kb = bytes / 1024;
+  return `${kb.toFixed(1)} KB`;
+}
+
+export default async function SourcesPage() {
+  const sources = await loadSources();
+
+  return (
+    <div>
+      <h1>Sources</h1>
+      {sources.length === 0 ? (
+        <div className="card empty-state">No sources uploaded yet.</div>
+      ) : (
+        sources.map((source) => (
+          <div key={source.id} className="card">
+            <h3>
+              <Link href={`/sources/${source.id}`}>{source.title}</Link>
+            </h3>
+            <p className="meta">
+              {source.original_file_name} · {formatSize(source.file_size)} ·{' '}
+              {new Date(source.created_at).toLocaleString()}
+            </p>
+            {source.description ? <p>{source.description}</p> : null}
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  eslint: {
+    dirs: ['app'],
+  },
+};
+
+export default nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "studium-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.15",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.12",
+    "@types/react": "18.3.12",
+    "@types/react-dom": "18.3.0",
+    "eslint": "8.57.1",
+    "eslint-config-next": "14.2.15",
+    "typescript": "5.6.3"
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/web/types/sources.ts
+++ b/web/types/sources.ts
@@ -1,0 +1,12 @@
+export type Source = {
+  id: string;
+  title: string;
+  description?: string | null;
+  owner_user_id?: string | null;
+  original_file_name: string;
+  content_type: string;
+  file_path: string;
+  file_size: number;
+  created_at: string;
+  updated_at: string;
+};


### PR DESCRIPTION
## Summary
- add FastAPI source model, migration, and endpoints for listing, uploading, and viewing PDF sources
- persist uploads to local storage with owner metadata stubbed for future OIDC
- scaffold Next.js SPA pages for browsing sources, uploading new PDFs, and viewing source details

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950d094d1508328865a6c8bda733f2f)